### PR TITLE
Updated ThrowUsage to not include JsonIdentityInfo

### DIFF
--- a/src/main/java/com/revature/models/ThrowUsage.java
+++ b/src/main/java/com/revature/models/ThrowUsage.java
@@ -27,7 +27,7 @@ public class ThrowUsage {
 	
 	@Embeddable
 	@Data @AllArgsConstructor @NoArgsConstructor
-	@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+	//@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
     static class Pk implements Serializable{
         @ManyToOne
         @JoinColumn(name = "user_id")

--- a/src/test/java/com/example/revature/RpsUltimateShowdownApiApplicationTests.java
+++ b/src/test/java/com/example/revature/RpsUltimateShowdownApiApplicationTests.java
@@ -71,11 +71,11 @@ class RpsUltimateShowdownApiApplicationTests {
 		
 		assertEquals(expectedUser, actualUser);
 	}
-		
-		
 	
-	//UserService Add Test Fail
 	//UserService GetByUserName Succeed
+	public void testSuccessfulGetByUsername() {
+		
+	}
 	//UserService GetByUserName Fail
 	//UserService GetById Succeed
 	//UserService GetByID Fail


### PR DESCRIPTION
This should stop the issues with Object Id invalid definition